### PR TITLE
refact(chart): use irme separated ports for status and metrics

### DIFF
--- a/charts/image-registry-metrics-exporter/Chart.yaml
+++ b/charts/image-registry-metrics-exporter/Chart.yaml
@@ -4,8 +4,8 @@ name: image-registry-metrics-exporter
 description: A Helm chart for Image Registry Metrics Exporter (IRME)
 
 type: application
-version: 0.2.0
-appVersion: 0.1.3
+version: 0.2.1
+appVersion: v0.1.6
 
 home: https://github.com/radiofrance/image-registry-metrics-exporter
 sources:

--- a/charts/image-registry-metrics-exporter/templates/deployment.yaml
+++ b/charts/image-registry-metrics-exporter/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       tolerations: {{ .Values.tolerations | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.topologySpreadConstraints }}
-      tolerations: {{ .Values.topologySpreadConstraints | toYaml | nindent 8 }}
+      topologySpreadConstraints: {{ .Values.topologySpreadConstraints | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/image-registry-metrics-exporter/templates/deployment.yaml
+++ b/charts/image-registry-metrics-exporter/templates/deployment.yaml
@@ -54,10 +54,6 @@ spec:
               value: "/src"
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/secret/credentials"
-            - name: WEB_LISTEN_ADDRESS
-              value: :{{ .Values.containerPorts.http }}
-            - name: TELEMETRY_LISTEN_ADDRESS
-              value: :{{ .Values.containerPorts.metrics }}
             - name: LOG_LEVEL
               value: {{ .Values.irme.logLevel }}
           ports:

--- a/charts/image-registry-metrics-exporter/templates/service.yaml
+++ b/charts/image-registry-metrics-exporter/templates/service.yaml
@@ -8,9 +8,13 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}80
+    - port: {{ .Values.service.ports.http }}
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.service.ports.metrics }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
   selector:
     {{- include "image-registry-metrics-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/image-registry-metrics-exporter/values.yaml
+++ b/charts/image-registry-metrics-exporter/values.yaml
@@ -138,8 +138,9 @@ containerSecurityContext:
 
 ## containerPorts -- Image Registry Metrics exporter container port
 containerPorts:
-  ## containerPorts.http -- Main exporter port, that receive webhook requests and export metrics
+  ## containerPorts.http -- Status exporter port, that expose health and readiness
   http: 8080
+  ## containerPorts.http -- Main exporter port, that expose metrics
   metrics: 9252
 
 ## resources -- Image Registry Metrics exporter pods' resource requests and limits
@@ -197,41 +198,10 @@ service:
   ## service.type -- Image Registry Metrics exporter Service type
   type: ClusterIP
   ports:
-    ## service.ports.http -- HTTP port for incoming webhooks
+    ## service.ports.http -- HTTP port for status
     http: 8080
     ## service.ports.metrics -- Metrics port to be scraped by prometheus
     metrics: 9252
-  nodePorts:
-    ## service.nodePorts.http -- node port for HTTP
-    http: ""
-    ## service.nodePorts.http -- node port for metrics
-    metrics: ""
-  ## service.clusterIP -- Image Registry Metrics exporter service Cluster IP
-  ## e.g.:
-  ## clusterIP: None
-  clusterIP: ""
-  ## service.loadBalancerSourceRanges -- Image Registry Metrics exporter service Load Balancer sources
-  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-  ## e.g:
-  ## loadBalancerSourceRanges:
-  ##   - 10.10.10.0/24
-  loadBalancerSourceRanges: []
-  ## service.annotations -- additional custom annotations for Image Registry Metrics exporter service
-  ## This can be used to set the LoadBalancer service type to internal only.
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
-  annotations: {}
-  ## service.externalTrafficPolicy -- Image Registry Metrics exporter service external traffic policy
-  ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
-  externalTrafficPolicy: Cluster
-  ## service.sessionAffinity -- session Affinity for Kubernetes service, can be "None" or "ClientIP"
-  ## If "ClientIP", consecutive client requests will be directed to the same pod
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
-  sessionAffinity: None
-  ## service.sessionAffinityConfig -- additional settings for the sessionAffinity
-  ## sessionAffinityConfig:
-  ##   clientIP:
-  ##     timeoutSeconds: 300
-  sessionAffinityConfig: {}
 
 ## metrics -- metrics parameters
 metrics:


### PR DESCRIPTION
IRME expose only one endpoint HTTP for health and metrics.
We simplify Helm Charts to reflect this state.
However, we keep metrics name on service as its used only for this purpose by an service monitor.