### PR TITLE
chore(dockerfile): use ARG for ca-certificates, remove unused package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-w -s -X 'main.version=${VERSION}'" ./cmd/image-registry-metrics-exporter
 
 FROM docker.io/alpine:3.18.0
+ARG CA_CERTIFICATES_VERSION=20230506-r0
 
 COPY --from=builder /build/image-registry-metrics-exporter /image-registry-metrics-exporter
 
-RUN apk update && apk add --no-cache ca-certificates=20230506-r0 \
-    && update-ca-certificates
+RUN apk update && apk add --no-cache ca-certificates=${CA_CERTIFICATES_VERSION}
 
 EXPOSE 9252
 USER 65534


### PR DESCRIPTION
Add Arg to specify ca-certificates package version to be more versatile 

Remove update-ca-certificates package as it is not used by app use case